### PR TITLE
add a transitive link dependency to main library

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -6,4 +6,5 @@
   <author>Sylvain Joyeux/sylvain.joyeux@tidewise.io</author>
   <license>Public Domain</license>
   <depend package="base/cmake" />
+  <depend package="build_tests/cmake/deps_target_transitive_dependency" />
 </package>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,16 @@
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(deps_target_transitive_dependency deps_target_transitive_dependency)
+
+find_library(deps_target_transitive_dependency_LIB deps_target_transitive_dependency
+    HINTS ${deps_target_transitive_dependency_LIBRARY_DIRS})
+
 rock_library(deps_target_dependency
     SOURCES Dummy.cpp
-    HEADERS Dummy.hpp)
+    HEADERS Dummy.hpp
+    LIBS ${deps_target_transitive_dependency_LIB})
+
 target_include_directories(deps_target_dependency INTERFACE ${CMAKE_INSTALL_PREFIX}/include)
+target_include_directories(deps_target_dependency INTERFACE ${deps_target_transitive_dependency_INCLUDE_DIRS})
 
 export(TARGETS deps_target_dependency FILE deps_target_dependency-config.cmake)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/deps_target_dependency-config.cmake


### PR DESCRIPTION
This adds a transitive link dependency from a non-standard location (the target binary dir, hence the `NOINSTALL`). The goal is to test rock-core/base-cmake#67.

Depends on:
 - [x] https://github.com/rock-core/base-cmake/pull/67
 - [x] https://github.com/rock-core/build_tests-cmake-deps_target_use_pkgconfig/pull/1
 - [x] https://github.com/rock-core/rock.build-tests-buildconf/pull/16