### PR TITLE
add a dependency on deps_target_dependency that is itself a CMake imported target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,21 +1,31 @@
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(deps_target_transitive_dependency deps_target_transitive_dependency)
+pkg_check_modules(deps_target_transitive_dependency_pkgconfig
+                  REQUIRED deps_target_transitive_dependency_pkgconfig)
+find_library(deps_target_transitive_dependency_pkgconfig_LIB
+    deps_target_transitive_dependency_pkgconfig
+    HINTS ${deps_target_transitive_dependency_pkgconfig_LIBRARY_DIRS})
 
-find_library(deps_target_transitive_dependency_LIB deps_target_transitive_dependency
-    HINTS ${deps_target_transitive_dependency_LIBRARY_DIRS})
+
+find_package(deps_target_transitive_dependency REQUIRED)
 
 rock_library(deps_target_dependency
     SOURCES Dummy.cpp
     HEADERS Dummy.hpp
-    LIBS ${deps_target_transitive_dependency_LIB})
+    LIBS ${deps_target_transitive_dependency_pkgconfig_LIB}
+    EXPORT dep)
 
 target_include_directories(deps_target_dependency INTERFACE ${CMAKE_INSTALL_PREFIX}/include)
-target_include_directories(deps_target_dependency INTERFACE ${deps_target_transitive_dependency_INCLUDE_DIRS})
+target_include_directories(deps_target_dependency INTERFACE ${deps_target_transitive_dependency_pkgconfig_INCLUDE_DIRS})
 
-export(TARGETS deps_target_dependency FILE deps_target_dependency-config.cmake)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/deps_target_dependency-config.cmake
+target_link_libraries(
+    deps_target_dependency
+    deps_target_transitive_dependency::deps_target_transitive_dependency_cmake)
+
+install(EXPORT dep
+        NAMESPACE deps_target_dependency::
+        DESTINATION lib/cmake/deps_target_dependency)
+install(FILES deps_target_dependency-config.cmake
         DESTINATION lib/cmake/deps_target_dependency)
 
 rock_executable(deps_target_dependency_bin Main.cpp
     DEPS deps_target_dependency)
-

--- a/src/deps_target_dependency-config.cmake
+++ b/src/deps_target_dependency-config.cmake
@@ -1,0 +1,4 @@
+find_package(deps_target_transitive_dependency REQUIRED)
+
+get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(${SELF_DIR}/dep.cmake)


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/build_tests-cmake-deps_target_transitive_dependency/pull/1
- [ ] https://github.com/rock-core/base-cmake/pull/68

The existing dependency was added manually, but discovered through
pkg-config. This dependency only uses the CMake export/import mechanism.

Internally (to CMake), it gets listed in the library's interface link
libraries as-is, i.e. using its target name. This allows us to ensure
that the base/cmake code handles it properly when exported to CMake
(i.e. resolves the library and puts its full path)